### PR TITLE
fix(package.json): add docfx.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "*.asmdef",
         "*.xml",
         "Documentation",
-        "Runtime"
+        "Runtime",
+        "docfx.json"
     ]
 }


### PR DESCRIPTION
The docfx.json file was missing from the package.json causing
the build process to fail. It has now been added.