### PR TITLE
feat(Prefabs): support precision grab offset - resolves #36

### DIFF
--- a/Documentation/API/DistanceGrabberConfigurator.md
+++ b/Documentation/API/DistanceGrabberConfigurator.md
@@ -8,8 +8,10 @@ Sets up the DistanceGrabber Prefab based on the provided user settings.
 * [Namespace]
 * [Syntax]
 * [Fields]
+  * [grabPoint]
   * [hasSubscribedToInteractorEvents]
 * [Properties]
+  * [AlwaysCreateGrabPoint]
   * [Facade]
   * [Grabber]
   * [GrabListener]
@@ -20,10 +22,13 @@ Sets up the DistanceGrabber Prefab based on the provided user settings.
   * [TargetValidityRules]
   * [UngrabListener]
 * [Methods]
+  * [CanCreateGrabPoint(GrabInteractableFollowAction)]
   * [ConfigureInteractor()]
   * [ConfigurePointerRules()]
   * [ConfigurePropertyApplier()]
   * [ConfigureReactivatePointerTimer()]
+  * [CreateGrabPoint(RaycastHit)]
+  * [DestroyGrabPoint()]
   * [OnDisable()]
   * [OnEnable()]
   * [PerformGrab(InteractableFacade)]
@@ -50,9 +55,19 @@ public class DistanceGrabberConfigurator : MonoBehaviour
 
 ### Fields
 
+#### grabPoint
+
+The point at which to use as the grab point offset for the transition.
+
+##### Declaration
+
+```
+protected GameObject grabPoint
+```
+
 #### hasSubscribedToInteractorEvents
 
-Whether the interactor events have been subscribed to.
+Whether the Interactor events have been subscribed to.
 
 ##### Declaration
 
@@ -61,6 +76,16 @@ protected bool hasSubscribedToInteractorEvents
 ```
 
 ### Properties
+
+#### AlwaysCreateGrabPoint
+
+Determines whether the grab point will be created always or only if the InteractableFacade has a follow action that is set to GrabInteractableFollowAction.OffsetType.PrecisionPoint.
+
+##### Declaration
+
+```
+public bool AlwaysCreateGrabPoint { get; set; }
+```
 
 #### Facade
 
@@ -94,7 +119,7 @@ public EmptyEventProxyEmitter GrabListener { get; protected set; }
 
 #### GrabProxy
 
-The BooleanAction that proxies the interactor's grab action.
+The BooleanAction that proxies the Interactor's grab action.
 
 ##### Declaration
 
@@ -114,7 +139,7 @@ public PointerFacade Pointer { get; protected set; }
 
 #### PropertyApplier
 
-The TransformPropertyApplier that transitions the interactable to the interactor.
+The TransformPropertyApplier that transitions the Interactable to the Interactor.
 
 ##### Declaration
 
@@ -154,9 +179,31 @@ public EmptyEventProxyEmitter UngrabListener { get; protected set; }
 
 ### Methods
 
+#### CanCreateGrabPoint(GrabInteractableFollowAction)
+
+Determines whether the grab point can be created for the given action.
+
+##### Declaration
+
+```
+protected virtual bool CanCreateGrabPoint(GrabInteractableFollowAction action)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GrabInteractableFollowAction | action | The action to check whether a grab point can be created for. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the grab point can be created. |
+
 #### ConfigureInteractor()
 
-Configures the relevant components that require knowledge of the interactor.
+Configures the relevant components that require knowledge of the Interactor.
 
 ##### Declaration
 
@@ -194,6 +241,32 @@ Configures the reactivate pointer timer.
 public virtual void ConfigureReactivatePointerTimer()
 ```
 
+#### CreateGrabPoint(RaycastHit)
+
+Creates the grab point offset to transition the target Interactable towards.
+
+##### Declaration
+
+```
+public virtual void CreateGrabPoint(RaycastHit hitData)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| RaycastHit | hitData | The data to create the point with. |
+
+#### DestroyGrabPoint()
+
+Destroys any existing grab point.
+
+##### Declaration
+
+```
+public virtual void DestroyGrabPoint()
+```
+
 #### OnDisable()
 
 ##### Declaration
@@ -224,7 +297,7 @@ protected virtual void PerformGrab(InteractableFacade interactable)
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractableFacade | interactable | The interactable being grabbed. |
+| InteractableFacade | interactable | The Interactable being grabbed. |
 
 #### PerformUngrab(InteractableFacade)
 
@@ -240,7 +313,7 @@ protected virtual void PerformUngrab(InteractableFacade interactable)
 
 | Type | Name | Description |
 | --- | --- | --- |
-| InteractableFacade | interactable | The interactable being grabbed. |
+| InteractableFacade | interactable | The Interactable being grabbed. |
 
 #### RegisterInteractorGrabListeners()
 
@@ -269,8 +342,10 @@ protected virtual void UnregisterInteractorGrabListeners()
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
+[grabPoint]: #grabPoint
 [hasSubscribedToInteractorEvents]: #hasSubscribedToInteractorEvents
 [Properties]: #Properties
+[AlwaysCreateGrabPoint]: #AlwaysCreateGrabPoint
 [Facade]: #Facade
 [Grabber]: #Grabber
 [GrabListener]: #GrabListener
@@ -281,10 +356,13 @@ protected virtual void UnregisterInteractorGrabListeners()
 [TargetValidityRules]: #TargetValidityRules
 [UngrabListener]: #UngrabListener
 [Methods]: #Methods
+[CanCreateGrabPoint(GrabInteractableFollowAction)]: #CanCreateGrabPointGrabInteractableFollowAction
 [ConfigureInteractor()]: #ConfigureInteractor
 [ConfigurePointerRules()]: #ConfigurePointerRules
 [ConfigurePropertyApplier()]: #ConfigurePropertyApplier
 [ConfigureReactivatePointerTimer()]: #ConfigureReactivatePointerTimer
+[CreateGrabPoint(RaycastHit)]: #CreateGrabPointRaycastHit
+[DestroyGrabPoint()]: #DestroyGrabPoint
 [OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
 [PerformGrab(InteractableFacade)]: #PerformGrabInteractableFacade

--- a/Documentation/API/InteractableGrabber.md
+++ b/Documentation/API/InteractableGrabber.md
@@ -1,12 +1,14 @@
 # Class InteractableGrabber
 
-Attempts to grab the given interactable to the given interactor.
+Attempts to grab the given Interactable to the given Interactor.
 
 ## Contents
 
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [Grabbed]
 * [Properties]
   * [Interactable]
   * [Interactor]
@@ -30,11 +32,23 @@ Attempts to grab the given interactable to the given interactor.
 public class InteractableGrabber : MonoBehaviour
 ```
 
+### Fields
+
+#### Grabbed
+
+Emitted when the Grab has occurred.
+
+##### Declaration
+
+```
+public UnityEvent Grabbed
+```
+
 ### Properties
 
 #### Interactable
 
-The interactable to grab.
+The Interactable to grab.
 
 ##### Declaration
 
@@ -44,7 +58,7 @@ public InteractableFacade Interactable { get; set; }
 
 #### Interactor
 
-The interactor to grab to.
+The Interactor to grab to.
 
 ##### Declaration
 
@@ -70,6 +84,8 @@ public virtual void DoGrab()
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[Grabbed]: #Grabbed
 [Properties]: #Properties
 [Interactable]: #Interactable
 [Interactor]: #Interactor

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -12,7 +12,7 @@ The public interface into the DistanceGrabber Prefab.
 
 #### [InteractableGrabber]
 
-Attempts to grab the given interactable to the given interactor.
+Attempts to grab the given Interactable to the given Interactor.
 
 [DistanceGrabberConfigurator]: DistanceGrabberConfigurator.md
 [DistanceGrabberFacade]: DistanceGrabberFacade.md

--- a/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
+++ b/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
@@ -80,6 +80,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7533518593231451648}
   - component: {fileID: 7533518593231451663}
+  - component: {fileID: 5499414486435190371}
   m_Layer: 0
   m_Name: GrabToInteractor
   m_TagString: Untagged
@@ -115,6 +116,55 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   interactor: {fileID: 0}
   interactable: {fileID: 0}
+  Grabbed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7533518594588224894}
+        m_MethodName: Receive
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &5499414486435190371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7533518593231451649}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f242ad1805431946acc4c338fa4d88b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Yielded:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7533518593231451663}
+        m_MethodName: DoGrab
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Cancelled:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!1 &7533518593574485166
 GameObject:
   m_ObjectHideFlags: 0
@@ -285,6 +335,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   facade: {fileID: 7533518594173930136}
+  alwaysCreateGrabPoint: 0
   pointer: {fileID: 5668053291574616488}
   grabber: {fileID: 7533518593231451663}
   propertyApplier: {fileID: 7533518594347027304}
@@ -5278,10 +5329,10 @@ MonoBehaviour:
     yState: 1
     zState: 1
   applyRotationOffsetOnAxis:
-    xState: 1
-    yState: 1
-    zState: 1
-  applyTransformations: 3
+    xState: 0
+    yState: 0
+    zState: 0
+  applyTransformations: 1
   transitionDuration: 0
   shouldApplyToEqualProperties: 1
   transitionDestinationThreshold: 0.01
@@ -5294,8 +5345,8 @@ MonoBehaviour:
   AfterTransformUpdated:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7533518593231451663}
-        m_MethodName: DoGrab
+      - m_Target: {fileID: 5499414486435190371}
+        m_MethodName: Begin
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -5355,6 +5406,17 @@ MonoBehaviour:
   Extracted:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 7533518594057795398}
+        m_MethodName: CreateGrabPoint
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 7533518594582477155}
         m_MethodName: DoExtract
         m_Mode: 0
@@ -5539,6 +5601,17 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 7533518593231451663}
         m_MethodName: ClearInteractable
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 7533518594057795398}
+        m_MethodName: DestroyGrabPoint
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -5969,6 +6042,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: Zinnia.Action.Action+BooleanUnityEvent, Zinnia.Runtime, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  initialValue: 0
   defaultValue: 0
   sources: []
   Activated:
@@ -6057,7 +6131,7 @@ PrefabInstance:
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
@@ -6068,11 +6142,11 @@ PrefabInstance:
         type: 3}
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 7533518594582477154}
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PrintString
+      value: DoExtract
       objectReference: {fileID: 0}
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
@@ -6082,7 +6156,7 @@ PrefabInstance:
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
-      value: dfg
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 3718142488040735482, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}

--- a/Runtime/SharedResources/Scripts/InteractableGrabber.cs
+++ b/Runtime/SharedResources/Scripts/InteractableGrabber.cs
@@ -7,24 +7,30 @@
     using Tilia.Interactions.Interactables.Interactables;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
+    using UnityEngine.Events;
 
     /// <summary>
-    /// Attempts to grab the given interactable to the given interactor.
+    /// Attempts to grab the given Interactable to the given Interactor.
     /// </summary>
     public class InteractableGrabber : MonoBehaviour
     {
         /// <summary>
-        /// The interactor to grab to.
+        /// The Interactor to grab to.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
         public InteractorFacade Interactor { get; set; }
         /// <summary>
-        /// The interactable to grab.
+        /// The Interactable to grab.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
         public InteractableFacade Interactable { get; set; }
+
+        /// <summary>
+        /// Emitted when the Grab has occurred.
+        /// </summary>
+        public UnityEvent Grabbed = new UnityEvent();
 
         /// <summary>
         /// Attempts to grab the <see cref="Interactable"/> to the <see cref="Interactor"/>.
@@ -38,6 +44,7 @@
             }
 
             Interactor.Grab(Interactable);
+            Grabbed?.Invoke();
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "1.21.0",
+        "io.extendreality.zinnia.unity": "1.22.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.1.0",
-        "io.extendreality.tilia.indicators.objectpointers.unity": "1.4.5",
-        "io.extendreality.tilia.interactions.interactables.unity": "1.12.2"
+        "io.extendreality.tilia.indicators.objectpointers.unity": "1.4.6",
+        "io.extendreality.tilia.interactions.interactables.unity": "1.13.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The Interactable precision grab offset is now supported when grabbing
with the distance grabbing pointer by creating a temporary GameObject
to use as the offset in the property applier.

The PropertyApplier also does not apply any rotation data now so the
snap is positional only.