### PR TITLE
fix(prefabs): ensure pointer is re-enabled if interactable disabled - fixes #110

### DIFF
--- a/Documentation/API/DistanceGrabberConfigurator.md
+++ b/Documentation/API/DistanceGrabberConfigurator.md
@@ -17,6 +17,7 @@ Sets up the DistanceGrabber Prefab based on the provided user settings.
   * [AlwaysCreateGrabPoint]
   * [DisablePointerOnInteractorTouch]
   * [EnablePointerContainer]
+  * [EnablePointerLogic]
   * [Facade]
   * [ForceKinematicOnTransition]
   * [Grabber]
@@ -156,6 +157,16 @@ The container for the logic that enables the pointer.
 
 ```
 public GameObject EnablePointerContainer { get; protected set; }
+```
+
+#### EnablePointerLogic
+
+The logic that enables the pointer.
+
+##### Declaration
+
+```
+public EmptyEventProxyEmitter EnablePointerLogic { get; protected set; }
 ```
 
 #### Facade
@@ -623,6 +634,7 @@ protected virtual void UnregisterInteractorListeners()
 [AlwaysCreateGrabPoint]: #AlwaysCreateGrabPoint
 [DisablePointerOnInteractorTouch]: #DisablePointerOnInteractorTouch
 [EnablePointerContainer]: #EnablePointerContainer
+[EnablePointerLogic]: #EnablePointerLogic
 [Facade]: #Facade
 [ForceKinematicOnTransition]: #ForceKinematicOnTransition
 [Grabber]: #Grabber

--- a/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
+++ b/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
@@ -7462,6 +7462,11 @@ PrefabInstance:
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
+        type: 3}
+      propertyPath: hoverValidity.field
+      value: 
+      objectReference: {fileID: 7533518594093266333}
     - target: {fileID: 3718142488040735482, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
       propertyPath: m_RootOrder

--- a/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
+++ b/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
@@ -838,6 +838,7 @@ MonoBehaviour:
     field: {fileID: 0}
   containingTransformValidity:
     field: {fileID: 0}
+  stayDelayInterval: 0
 --- !u!1 &6972322886875384934
 GameObject:
   m_ObjectHideFlags: 0
@@ -960,6 +961,7 @@ MonoBehaviour:
   Deactivated:
     m_PersistentCalls:
       m_Calls: []
+  value: 0
 --- !u!1 &7248696514879030278
 GameObject:
   m_ObjectHideFlags: 0
@@ -1351,6 +1353,7 @@ MonoBehaviour:
   grabProxyActions: {fileID: 431940976625598158}
   reactivatePointerTimer: {fileID: 7533518594070652894}
   enablePointerContainer: {fileID: 3588313746156001542}
+  enablePointerLogic: {fileID: 5389908358366618350}
   targetValidityRules: {fileID: 7533518595170314445}
   simulatedInteractor: {fileID: 7943924944593853601}
 --- !u!1 &7533518594070652880
@@ -2972,7 +2975,6 @@ ParticleSystem:
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   UVModule:
-    serializedVersion: 2
     enabled: 0
     mode: 0
     timeMode: 0
@@ -3090,7 +3092,7 @@ ParticleSystem:
     rowIndex: 0
     cycles: 1
     uvChannelMask: -1
-    rowMode: 1
+    randomRow: 1
     sprites:
     - sprite: {fileID: 0}
     flipU: 0
@@ -3901,61 +3903,8 @@ ParticleSystem:
     inWorldSpace: 0
     randomizePerFrame: 0
   ExternalForcesModule:
-    serializedVersion: 2
     enabled: 0
-    multiplierCurve:
-      serializedVersion: 2
-      minMaxState: 0
-      scalar: 1
-      minScalar: 1
-      maxCurve:
-        serializedVersion: 2
-        m_Curve:
-        - serializedVersion: 3
-          time: 0
-          value: 1
-          inSlope: 0
-          outSlope: 0
-          tangentMode: 0
-          weightedMode: 0
-          inWeight: 0.33333334
-          outWeight: 0.33333334
-        - serializedVersion: 3
-          time: 1
-          value: 1
-          inSlope: 0
-          outSlope: 0
-          tangentMode: 0
-          weightedMode: 0
-          inWeight: 0.33333334
-          outWeight: 0.33333334
-        m_PreInfinity: 2
-        m_PostInfinity: 2
-        m_RotationOrder: 4
-      minCurve:
-        serializedVersion: 2
-        m_Curve:
-        - serializedVersion: 3
-          time: 0
-          value: 1
-          inSlope: 0
-          outSlope: 0
-          tangentMode: 0
-          weightedMode: 0
-          inWeight: 0.33333334
-          outWeight: 0.33333334
-        - serializedVersion: 3
-          time: 1
-          value: 1
-          inSlope: 0
-          outSlope: 0
-          tangentMode: 0
-          weightedMode: 0
-          inWeight: 0.33333334
-          outWeight: 0.33333334
-        m_PreInfinity: 2
-        m_PostInfinity: 2
-        m_RotationOrder: 4
+    multiplier: 1
     influenceFilter: 0
     influenceMask:
       serializedVersion: 2
@@ -6317,7 +6266,6 @@ ParticleSystemRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -6330,7 +6278,6 @@ ParticleSystemRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -7247,6 +7194,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+  value: 0
 --- !u!1 &8579821686344643671
 GameObject:
   m_ObjectHideFlags: 0
@@ -7363,16 +7311,6 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
-      propertyPath: selectionAction
-      value: 
-      objectReference: {fileID: 7533518595176635480}
-    - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
-        type: 3}
-      propertyPath: targetValidity.field
-      value: 
-      objectReference: {fileID: 7533518594093266333}
-    - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
-        type: 3}
       propertyPath: Exited.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
@@ -7386,6 +7324,16 @@ PrefabInstance:
       propertyPath: Selected.m_PersistentCalls.m_Calls.Array.size
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
+        type: 3}
+      propertyPath: selectionAction
+      value: 
+      objectReference: {fileID: 7533518595176635480}
+    - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
+        type: 3}
+      propertyPath: targetValidity.field
+      value: 
+      objectReference: {fileID: 7533518594093266333}
     - target: {fileID: 2748488038835702461, guid: 1950b2150beec924d9cff768bb4e815c,
         type: 3}
       propertyPath: Exited.m_PersistentCalls.m_Calls.Array.data[0].m_Mode

--- a/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
+++ b/Runtime/Prefabs/Interactions.PointerInteractors.DistanceGrabber.prefab
@@ -1502,6 +1502,7 @@ GameObject:
   - component: {fileID: 7533518594173930137}
   - component: {fileID: 7533518594173930136}
   - component: {fileID: 7393450506313436259}
+  - component: {fileID: 2460182061687048909}
   m_Layer: 0
   m_Name: Interactions.PointerInteractors.DistanceGrabber
   m_TagString: Untagged
@@ -1543,7 +1544,7 @@ MonoBehaviour:
   ungrabDelay: 1
   targetValidity:
     field: {fileID: 7393450506313436259}
-  raycastRules: {fileID: 0}
+  raycastRules: {fileID: 2460182061687048909}
   BeforeGrabbed:
     m_PersistentCalls:
       m_Calls: []
@@ -1568,6 +1569,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   autoRejectStates: -1
   rules: {fileID: 7905425836278180756}
+--- !u!114 &2460182061687048909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7533518594173930138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layersToIgnore:
+    serializedVersion: 2
+    m_Bits: 4
+  triggerInteraction: 1
+  convertTo: {fileID: 0}
 --- !u!1 &7533518594224638937
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/DistanceGrabberConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/DistanceGrabberConfigurator.cs
@@ -279,6 +279,24 @@
                 enablePointerContainer = value;
             }
         }
+        [Tooltip("The logic that enables the pointer.")]
+        [SerializeField]
+        [Restricted]
+        private EmptyEventProxyEmitter enablePointerLogic;
+        /// <summary>
+        /// The logic that enables the pointer.
+        /// </summary>
+        public EmptyEventProxyEmitter EnablePointerLogic
+        {
+            get
+            {
+                return enablePointerLogic;
+            }
+            protected set
+            {
+                enablePointerLogic = value;
+            }
+        }
         [Tooltip("The RuleContainerObservableList that controls pointer target validity.")]
         [SerializeField]
         [Restricted]
@@ -646,7 +664,17 @@
         protected virtual void HasUntouched(InteractableFacade interactable)
         {
             EnablePointerContainer.SetActive(true);
-            if (!DisablePointerOnInteractorTouch || ShouldIgnoreEnablePointer)
+            if (ShouldIgnoreEnablePointer)
+            {
+                if (interactable == null || !interactable.gameObject.activeInHierarchy)
+                {
+                    EnablePointerLogic.Receive();
+                    ShouldIgnoreEnablePointer = false;
+                }
+                return;
+            }
+
+            if (!DisablePointerOnInteractorTouch)
             {
                 return;
             }


### PR DESCRIPTION
If the Interactable is disabled or destroyed after the pointer grabber
has grabbed it, then the relevant logic to re-enable the pointer
grabber wasn't being run and therefore the pointer grabber was no
longer working.

This fix checks to see if the grabbed interactable is still available
in the scene and if its not then it forcefully calls the enable pointer
logic to ensure it is re-enabled correctly.